### PR TITLE
Fix naming of timestamp header field

### DIFF
--- a/msg/Header.msg
+++ b/msg/Header.msg
@@ -1,7 +1,7 @@
 int32 headerId      # header ID of the message. The headerId is defined per topic and incremented by 1 with each sent 
                     # (but not necessarily received) message.
 
-string timeStamp    # Timestamp after ISO8601 in the format YYYY-MM-DDTHH:mm:ss.ssZ (e.g.“2017-04-15T11:40:03.12Z”)
+string timestamp    # Timestamp after ISO8601 in the format YYYY-MM-DDTHH:mm:ss.ssZ (e.g.“2017-04-15T11:40:03.12Z”)
 
 string version      # Version of the protocol [Major].[Minor].[Patch] (e.g. 1.3.2)
 

--- a/msg/InstantActions.msg
+++ b/msg/InstantActions.msg
@@ -1,7 +1,7 @@
 int32 headerId      # header ID of the message. The headerId is defined per topic and incremented by 1 with each sent 
                     # (but not necessarily received) message.
 
-string timeStamp    # Timestamp after ISO8601 in the format YYYY-MM-DDTHH:mm:ss.ssZ (e.g.“2017-04-15T11:40:03.12Z”)
+string timestamp    # Timestamp after ISO8601 in the format YYYY-MM-DDTHH:mm:ss.ssZ (e.g.“2017-04-15T11:40:03.12Z”)
 
 string version      # Version of the protocol [Major].[Minor].[Patch] (e.g. 1.3.2)
 

--- a/msg/OrderInformation.msg
+++ b/msg/OrderInformation.msg
@@ -2,7 +2,7 @@
 int32 headerId                                       # header ID of the message. The headerId is defined per topic and incremented by 1 with each sent
                                                      # (but not necessarily received) message.
 
-string timeStamp                                     # Timestamp after ISO8601 in the format YYYY-MM-DDTHH:mm:ss.ssZ (e.g.“2017-04-15T11:40:03.12Z”)
+string timestamp                                     # Timestamp after ISO8601 in the format YYYY-MM-DDTHH:mm:ss.ssZ (e.g.“2017-04-15T11:40:03.12Z”)
 
 string version                                       # Version of the protocol [Major].[Minor].[Patch] (e.g. 1.3.2)
 

--- a/msg/Visualization.msg
+++ b/msg/Visualization.msg
@@ -2,7 +2,7 @@
 int32 headerId          # header ID of the message. The headerId is defined per topic and incremented by 1 with each sent
                         # (but not necessarily received) message.
 
-string timeStamp        # Timestamp after ISO8601 in the format YYYY-MM-DDTHH:mm:ss.ssZ (e.g.“2017-04-15T11:40:03.12Z”)
+string timestamp        # Timestamp after ISO8601 in the format YYYY-MM-DDTHH:mm:ss.ssZ (e.g.“2017-04-15T11:40:03.12Z”)
 
 string version          # Version of the protocol [Major].[Minor].[Patch] (e.g. 1.3.2)
 


### PR DESCRIPTION
we had a mix of timeStamp and timestamp

I'm changing everything to v1.1 which is timestamp