### PR TITLE
remove surrounding quotes of string constants

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ env:
     - ROS_REPO=ros
     - NOT_TEST_INSTALL=true
   matrix:
-    - ROS_DISTRO=kinetic UPSTREAM_WORKSPACE=debian
     - ROS_DISTRO=melodic UPSTREAM_WORKSPACE=debian
+    - ROS_DISTRO=noetic UPSTREAM_WORKSPACE=debian
 matrix:
   allow_failures:
     - env: ROS_DISTRO=melodic UPSTREAM_WORKSPACE=debian

--- a/msg/Action.msg
+++ b/msg/Action.msg
@@ -29,6 +29,6 @@ vda5050_msgs/ActionParameter[] actionParameters                 # Array of actio
 
 
 # Enums for blockingType
-string NONE = "NONE"
-string SOFT = "SOFT"
-string HARD = "HARD"
+string NONE=NONE
+string SOFT=SOFT
+string HARD=HARD

--- a/msg/Connection.msg
+++ b/msg/Connection.msg
@@ -16,6 +16,6 @@ string connection_state # Enum{ONLINE, OFFLINE, CONNECTIONBROKEN}
                         # CONNECTIONBROKEN: The connection between  AGV and  broker  has unexpectedly ended.
 
 
-string ONLINE="ONLINE"
-string OFFLINCE="OFFLINE"
-string CONNECTIONBROKEN="CONNECTIONBROKEN"
+string ONLINE=ONLINE
+string OFFLINCE=OFFLINE
+string CONNECTIONBROKEN=CONNECTIONBROKEN

--- a/msg/CurrentAction.msg
+++ b/msg/CurrentAction.msg
@@ -6,8 +6,8 @@ string resultDescription  # Description of the result, e.g. the result of a RFID
                           # errors. Examples for results are given in 5.2
 
 # Enums for actionStatus
-string WAITING="waiting"
-string INITIALIZING="initializing"
-string RUNNING="running"
-string FINISHED="finished"
-string FAILED="failed"
+string WAITING=waiting
+string INITIALIZING=initializing
+string RUNNING=running
+string FINISHED=finished
+string FAILED=failed

--- a/msg/Error.msg
+++ b/msg/Error.msg
@@ -8,5 +8,5 @@ string errorLevel                             # Enum {warning, fatal} warning: A
                                               # intervention required (e.g. laser scanner is contaminated)
 
 # Enums for errorLevel
-string WARNING="warning"
-string FATAL="fatal"
+string WARNING=warning
+string FATAL=fatal

--- a/msg/Info.msg
+++ b/msg/Info.msg
@@ -4,5 +4,5 @@ string infoDescription                      # Info description
 string infoLevel                            # Enum {DEBUG, INFO} DEBUG: used for debugging, INFO: used for visualization
 
 
-string DEBUG="DEBUG"
-string INFO="INFO"
+string DEBUG=DEBUG
+string INFO=INFO

--- a/msg/OrderInformation.msg
+++ b/msg/OrderInformation.msg
@@ -80,17 +80,17 @@ vda5050_msgs/Info informations                       # Array of info-objects. An
 
 
                                                      # Enums for operatingMode
-string AUTOMATIC="AUTOMATIC"
+string AUTOMATIC=AUTOMATIC
 
                                                      # AGV is under full control of the supervisor. AGV drives and executes actions based on orders from the supervisor
-string SEMIAUTOMATIC="SEMIAUTOMATIC"
+string SEMIAUTOMATIC=SEMIAUTOMATIC
 
                                                      # AGV is under control of the supervisor. AGV drives and executes actions based on orders from the supervisor. The driving speeds is controlled by the HMI. (speed can’t exceed the speed of automatic mode) The steering is under automatic control. (non-safe HMI possible)
-string MANUAL="MANUAL"
+string MANUAL=MANUAL
 
                                                      # Supervisor is not in control of the AGV. Supervisor doesn’t send driving order or actions to the AGV. HMI can be used the control the steering and velocity and handling device of the AGV. Location of the AGV is send to the supervisor. When AGV enters or leaves this mode, it immediately clears all the orders. (safe HMI required)
                                                      # Supervisor is not in control of the AGV. Supervisor doesn’t send driving order or actions to the AGV. Authorized personal can reconfigure the AGV.
-string SERVICE="SERVICE"
+string SERVICE=SERVICE
 
                                                      # Supervisor is not in control of the AGV. Supervisor doesn’t send driving order or actions to the AGV. The AGV is being taught, e.g. mapping is done by a supervisor
-string TEACHIN="TEACHIN"
+string TEACHIN=TEACHIN

--- a/msg/SafetyState.msg
+++ b/msg/SafetyState.msg
@@ -6,7 +6,7 @@ string eStop            # Enum {autoAck, manual, remote, none} Acknowledge-Type 
 bool fieldViolation     # Protective field violation. True: field is violated False: field is not violated 
 
 # Enums for eStop
-string AUTO_ACK="autoAck"
-string MANUAL="manual"
-string REMOTE="remote"
-string NONE="none"
+string AUTO_ACK=autoAck
+string MANUAL=manual
+string REMOTE=remote
+string NONE=none


### PR DESCRIPTION
having quotes generates string constants like `\"foo\"` which is obviously not what we want.