### PR TITLE
NodeState.msg has incorrect member name

### DIFF
--- a/vda5050_msgs/msg/NodeState.msg
+++ b/vda5050_msgs/msg/NodeState.msg
@@ -3,6 +3,6 @@
 string node_id                                      # Unique node identification
 uint32 sequence_id                                  # sequenceId to discern multiple nodes with same nodeId.
 string node_description                             # Additional information on the node
-vda5050_msgs/NodePosition position                  # Node position (see Topic: Order)
+vda5050_msgs/NodePosition node_position             # Node position (see Topic: Order)
 bool released                                       # true indicates that the node is part of the base. 
                                                     # false indicates that the node is part of the horizon.


### PR DESCRIPTION
In NodeState.msg, the NodePosition member should have name of `node_position`; it was just `position`. This matches both with the v2 NodePosition spec and the Node.msg definition.